### PR TITLE
fix: 최초 로그인 시, 멤버리스트를 가져오지 못하는 현상 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,13 @@ import { ReactQueryDevtools } from 'react-query/devtools'
 import Routes from '@/routes/routes'
 import { Toaster } from 'react-hot-toast'
 
-const queryClient = new QueryClient()
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+    },
+  },
+})
 
 const App = () => {
   return (

--- a/src/features/project/services/index.ts
+++ b/src/features/project/services/index.ts
@@ -94,11 +94,7 @@ export function useProjectTokenService(projectId: number) {
   )
 }
 
-export function useProjectMembersService(
-  projectId: number,
-  payload: ProjectPayload.Members,
-) {
-  const getProjectToken = useStore(state => state.getProjectToken)
+export function useProjectMembersService(payload: ProjectPayload.Members) {
   return useQuery(
     [
       'projects',
@@ -108,7 +104,6 @@ export function useProjectMembersService(
     ],
     () => ProjectService.getProjectMembers(payload),
     {
-      enabled: !!getProjectToken(projectId),
       retry: false,
     },
   )

--- a/src/features/project/services/index.ts
+++ b/src/features/project/services/index.ts
@@ -94,16 +94,23 @@ export function useProjectTokenService(projectId: number) {
   )
 }
 
-export function useProjectMembersService(payload: ProjectPayload.Members) {
+export function useProjectMembersService(
+  projectId: number,
+  payload: ProjectPayload.Members,
+) {
+  const getProjectToken = useStore(state => state.getProjectToken)
   return useQuery(
     [
       'projects',
       'getProjectMembers',
+      `projectId=${projectId}`,
       `offset=${payload?.offset}`,
       `limit=${payload?.limit}`,
     ],
     () => ProjectService.getProjectMembers(payload),
     {
+      enabled: getToken() !== null && !!getProjectToken(projectId),
+      keepPreviousData: true,
       retry: false,
     },
   )

--- a/src/features/project/views/ProjectDashboard.tsx
+++ b/src/features/project/views/ProjectDashboard.tsx
@@ -18,19 +18,20 @@ const ProjectTop = () => {
 const ProjectDashBoard = () => {
   const { projectId } = useParams()
 
-  const { data, isLoading } = useProjectTokenService(Number(projectId))
-
-  const projectToken = data?.token
+  const { data } = useProjectTokenService(Number(projectId))
 
   const setCurrentProjectId = useStore(state => state.setCurrentProjectId)
   const setApplicationToken = useStore(state => state.setApplicationToken)
   const getProjectToken = useStore(state => state.getProjectToken)
 
-  const { data: members, refetch: refetchProjectMembers } =
-    useProjectMembersService({
-      offset: 0,
-      limit: 200,
-    })
+  const {
+    data: members,
+    refetch: refetchProjectMembers,
+    isError,
+  } = useProjectMembersService(Number(projectId), {
+    offset: 0,
+    limit: 200,
+  })
 
   useEffect(() => {
     if (!getProjectToken(Number(projectId))) {
@@ -39,9 +40,11 @@ const ProjectDashBoard = () => {
   }, [projectId])
 
   useEffect(() => {
+    const projectToken = data?.token
+
     if (!projectToken) {
       // 응답이 정상이 아닌 경우에는 에러 메시지를 보여준다.
-      !isLoading && toast.error('프로젝트 토큰을 가져오는데 실패했습니다.')
+      isError && toast.error('프로젝트 토큰을 가져오는데 실패했습니다.')
       return
     }
 
@@ -53,7 +56,7 @@ const ProjectDashBoard = () => {
     map[Number(projectId)] = projectToken
     setApplicationToken(map)
     refetchProjectMembers()
-  }, [data, isLoading])
+  }, [data?.token])
 
   return (
     <View type="full">


### PR DESCRIPTION
## AS-IS : 재현 경로
1. 그 어떤 상태도 남아있지 않은 상태에서
2. 최초 로그인 이후 아무 프로젝트를 클릭
3. 멤버리스트가 보이지 않음

## TO-BE : 원인과 해결
- application token을 가져오는 `useProjectTokenService` 훅과 `useProjectMembersService` 가 동시에 실행됨.
- 둘이 순차적으로 실행되야 하는데 그렇지 못하여, project token이 존재하는지의 상태변화를 체크하여 순차적으로 실행되도록 수정
- 그 외에 일부 파라미터 수정